### PR TITLE
Reduce haptics buffer size from 256 to 64 samples

### DIFF
--- a/include/devices/haptics.h
+++ b/include/devices/haptics.h
@@ -21,7 +21,7 @@ typedef enum
 } rumble_t;
 
 void haptic_config_cmd(haptic_cmd_t cmd, webreport_cmd_confirm_t cb);
-void haptics_set_hd(haptic_processed_s *input);
+void haptics_set_hd(haptic_packet_s *packet);
 void haptics_set_std(uint8_t amplitude, bool brake);
 void haptics_stop();
 bool haptics_init();

--- a/include/devices_shared_types.h
+++ b/include/devices_shared_types.h
@@ -44,7 +44,7 @@ typedef struct
     uint16_t value;
 } hsv_s;
 
-typedef struct 
+typedef struct
 {
     uint16_t    hi_amplitude_fixed;
     uint16_t    lo_amplitude_fixed;
@@ -52,6 +52,12 @@ typedef struct
     uint16_t    lo_frequency_increment;
     uint8_t     sample_len; // How many sample chunks
 } haptic_processed_s;
+
+typedef struct
+{
+    haptic_processed_s pairs[3];
+    uint8_t count;
+} haptic_packet_s;
 
 typedef union
 {

--- a/include/hal/erm_hal.h
+++ b/include/hal/erm_hal.h
@@ -22,7 +22,7 @@
 void erm_hal_stop();
 bool erm_hal_init(uint8_t intensity);
 void erm_hal_task(uint64_t timestamp);
-void erm_hal_push_amfm(haptic_processed_s *input);
+void erm_hal_push_amfm(haptic_packet_s *packet);
 void erm_hal_set_standard(uint8_t intensity, bool brake);
 
 #endif

--- a/include/hal/lra_hal.h
+++ b/include/hal/lra_hal.h
@@ -22,7 +22,7 @@
 void lra_hal_stop();
 bool lra_hal_init(uint8_t intensity);
 void lra_hal_task(uint64_t timestamp);
-void lra_hal_push_amfm(haptic_processed_s *input);
+void lra_hal_push_amfm(haptic_packet_s *packet);
 void lra_hal_set_standard(uint8_t intensity, bool brake);
 #endif
 

--- a/include/utilities/pcm.h
+++ b/include/utilities/pcm.h
@@ -78,7 +78,7 @@ void pcm_play_bump(bool left, bool right);
 #endif
 
 void pcm_send_pulse();
-bool pcm_amfm_push(haptic_processed_s *value);
+bool pcm_amfm_push(haptic_packet_s *packet);
 void pcm_generate_buffer(uint32_t *buffer);
 
 #endif

--- a/src/devices/haptics.c
+++ b/src/devices/haptics.c
@@ -33,10 +33,10 @@ void haptic_config_cmd(haptic_cmd_t cmd, webreport_cmd_confirm_t cb)
     }
 }
 
-void haptics_set_hd(haptic_processed_s *input)
+void haptics_set_hd(haptic_packet_s *packet)
 {
     #if defined(HOJA_HAPTICS_PUSH_AMFM)
-    HOJA_HAPTICS_PUSH_AMFM(input);
+    HOJA_HAPTICS_PUSH_AMFM(packet);
     #endif
 }
 

--- a/src/hal/rp2040/erm_hal.c
+++ b/src/hal/rp2040/erm_hal.c
@@ -187,12 +187,19 @@ void erm_hal_set_standard(uint8_t intensity, bool brake)
     _target_level = target;
 }
 
-void erm_hal_push_amfm(haptic_processed_s *input)
+void erm_hal_push_amfm(haptic_packet_s *packet)
 {
-    static bool lock = false;
-    uint16_t working_amp = (input->hi_amplitude_fixed > input->lo_amplitude_fixed) ? input->hi_amplitude_fixed : input->lo_amplitude_fixed;
-    
-    if(!working_amp) 
+    // Use the first pair (or find max amplitude across all pairs)
+    uint16_t working_amp = 0;
+    for(int i = 0; i < packet->count && i < 3; i++)
+    {
+        uint16_t pair_amp = (packet->pairs[i].hi_amplitude_fixed > packet->pairs[i].lo_amplitude_fixed)
+            ? packet->pairs[i].hi_amplitude_fixed
+            : packet->pairs[i].lo_amplitude_fixed;
+        if(pair_amp > working_amp) working_amp = pair_amp;
+    }
+
+    if(!working_amp)
     {
         erm_hal_set_standard(0, false);
         return;
@@ -203,7 +210,6 @@ void erm_hal_push_amfm(haptic_processed_s *input)
     new_intensity = new_intensity > 255 ? 255 : new_intensity;
 
     erm_hal_set_standard((uint8_t) new_intensity, false);
-        
 }
 
 #endif

--- a/src/hal/rp2040/lra_hal.c
+++ b/src/hal/rp2040/lra_hal.c
@@ -309,10 +309,10 @@ void lra_hal_task(uint64_t timestamp)
     }
 }
 
-void lra_hal_push_amfm(haptic_processed_s *input)
+void lra_hal_push_amfm(haptic_packet_s *packet)
 {
     _erm_simulation_enabled = false; // Unset our ERM simulation mode
-    pcm_amfm_push(input);
+    pcm_amfm_push(packet);
 }
 
 void lra_hal_set_standard(uint8_t intensity, bool brake)

--- a/src/usb/sinput.c
+++ b/src/usb/sinput.c
@@ -248,7 +248,7 @@ const uint8_t sinput_configuration_descriptor[] = {
 
 void sinput_cmd_haptics(const uint8_t *data)
 {
-    haptic_processed_s val = {0};
+    haptic_packet_s packet = {0};
 
     sinput_haptic_s haptic = {0};
 
@@ -262,17 +262,17 @@ void sinput_cmd_haptics(const uint8_t *data)
         case 1:
             float a1_base = (float) (haptic.type_1.left.amplitude_1 > haptic.type_1.right.amplitude_1 ? haptic.type_1.left.amplitude_1 : haptic.type_1.right.amplitude_1);
             float a2_base = (float) (haptic.type_1.left.amplitude_2 > haptic.type_1.right.amplitude_2 ? haptic.type_1.left.amplitude_2 : haptic.type_1.right.amplitude_2);
-            
+
             float amp_1 = a1_base > 0 ? (float) a1_base / (float) UINT16_MAX : 0;
             float amp_2 = a2_base > 0 ? (float) a2_base / (float) UINT16_MAX : 0;
-        
-            val.hi_amplitude_fixed = pcm_amplitude_to_fixedpoint(amp_1);
-            val.lo_amplitude_fixed = pcm_amplitude_to_fixedpoint(amp_2);
-        
-            val.hi_frequency_increment = pcm_frequency_to_fixedpoint_increment((float) haptic.type_1.left.frequency_1);
-            val.lo_frequency_increment = pcm_frequency_to_fixedpoint_increment((float) haptic.type_1.left.frequency_2);
-        
-            pcm_amfm_push(&val);
+
+            packet.count = 1;
+            packet.pairs[0].hi_amplitude_fixed = pcm_amplitude_to_fixedpoint(amp_1);
+            packet.pairs[0].lo_amplitude_fixed = pcm_amplitude_to_fixedpoint(amp_2);
+            packet.pairs[0].hi_frequency_increment = pcm_frequency_to_fixedpoint_increment((float) haptic.type_1.left.frequency_1);
+            packet.pairs[0].lo_frequency_increment = pcm_frequency_to_fixedpoint_increment((float) haptic.type_1.left.frequency_2);
+
+            pcm_amfm_push(&packet);
         break;
 
         case 2:


### PR DESCRIPTION
Decreases (maximum) buffer latency from ~128ms to ~32ms by reducing PCM_BUFFER_SIZE