### PR TITLE
Add snapback cancel threshold for intentional direction changes

### DIFF
--- a/include/input_shared_types.h
+++ b/include/input_shared_types.h
@@ -120,11 +120,11 @@ typedef enum
     CALIBRATE_SAVE,
 } calibrate_set_t;
 
-typedef enum 
+typedef enum
 {
+    SNAPBACK_TYPE_AUTO,
+    SNAPBACK_TYPE_LPF,
     SNAPBACK_TYPE_DISABLED,
-    SNAPBACK_TYPE_ZERO,
-    SNAPBACK_TYPE_POST,
 } snapback_type_t;
 
 // IMU data structure


### PR DESCRIPTION
When snapback detection triggers, if the stick travels more than 50 units past the trigger point, cancel and output real values. This allows quick intentional direction changes to pass through without being blocked.

Also rename snapback_type_t enum values to match actual behavior.